### PR TITLE
source a local zshrc configuration if it exists

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -74,5 +74,7 @@ fi
 
 . "${HOME}/.nix-profile/etc/profile.d/hm-session-vars.sh"
 
+[[ -e "${HOME}/.zshrc.local" ]] && . "${HOME}/.zshrc.local
+
 [[ $- != *i* ]] && return
 [[ -z "${TMUX}" ]] && exec tmux new-session -A -s default


### PR DESCRIPTION
This allows machines requiring extra configuration (e.g., a work Mac) to
load machine specific configurations.