### PR TITLE
Minimal working Haskell tools list.

### DIFF
--- a/languages/haskell.nix
+++ b/languages/haskell.nix
@@ -3,8 +3,8 @@
   home.packages = [
     pkgs.cabal2nix
     pkgs.cabal-install
-    #pkgs.haskellPackages.brittany
-    pkgs.haskellPackages.haskell-ci
+    pkgs.haskellPackages.brittany
+    #pkgs.haskellPackages.haskell-ci
     pkgs.haskellPackages.haskell-lsp
     pkgs.haskellPackages.haskell-lsp-types
     pkgs.haskellPackages.hpack


### PR DESCRIPTION
The tools that don't build or work on 20.03 has changed slightly.  This
works around that for now.