### PR TITLE
Drop tabspaces from alacritty configuration.

### DIFF
--- a/programs/alacritty.nix
+++ b/programs/alacritty.nix
@@ -11,7 +11,6 @@
         dynamic_padding = true;
       };
       scrolling.history = 0;
-      tabspaces = 4;
       font = {
         normal.family = "Noto Sans Mono";
         size = 5.0;


### PR DESCRIPTION
This is now defaulted to 8 with no option to configure.