### PR TITLE
Separate home-manager configuration.

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -39,61 +39,19 @@
     };
   };
 
-  programs.home-manager = {
-    enable = true;
-    path = https://github.com/rycee/home-manager/archive/release-19.09.tar.gz;
-  };
-
   systemd.user = {
-    services = {
-      /* TODO
-      "home-manager-switch" = {
-        Unit = {
-          Description = "home-manager switch";
-          Documentation = "https://rycee.gitlab.io/home-manager/options.html";
-        };
-
-        Service = {
-          ExecStart = "home-manager switch";
-          Environment = "PATH=${pkgs.nix}/bin";
-        };
+    services."nix-env-update" = {
+      Unit = {
+        Description = "nix-env -u";
+        Documentation = "man:nix-env(1)";
       };
-      */
 
-      "nix-env-update" = {
-        Unit = {
-          Description = "nix-env -u";
-          Documentation = "man:nix-env(1)";
-        };
-
-        Service = {
-          ExecStart = "${pkgs.nix}/bin/nix-env -u";
-        };
-      };
+      Service.ExecStart = "${pkgs.nix}/bin/nix-env -u";
     };
 
-    timers = {
-      /* TODO
-      "home-manager-switch" = {
-        Timer = {
-          OnCalendar = "daily";
-        };
-
-        Install = {
-          WantedBy = [ "timers.target" ];
-        };
-      };
-      */
-
-      "nix-env-update" = {
-        Timer = {
-          OnCalendar = "daily";
-        };
-
-        Install = {
-          WantedBy = [ "timers.target" ];
-        };
-      };
+    timers."nix-env-update" = {
+      Timer.OnCalendar = "daily";
+      Install.WantedBy = [ "timers.target" ];
     };
   };
 }

--- a/programs/default.nix
+++ b/programs/default.nix
@@ -5,6 +5,7 @@
     ./bashtop
     ./direnv.nix
     ./gpg.nix
+    ./home-manager.nix
     ./htop.nix
     ./tmux
     ./vim

--- a/programs/home-manager.nix
+++ b/programs/home-manager.nix
@@ -1,0 +1,45 @@
+{ ... }:
+{
+  programs.home-manager = {
+    enable = true;
+    path = https://github.com/rycee/home-manager/archive/release-20.03.tar.gz;
+  };
+
+  systemd.user = {
+    services = {
+      "home-manager-switch" = {
+        Unit = {
+          Description = "home-manager switch";
+          Documentation = "https://rycee.gitlab.io/home-manager/options.html";
+        };
+
+        Service = {
+          ExecStart = "%h/.nix-profile/bin/home-manager switch";
+          Environment = "PATH=\${PATH}:/run/current-system/sw/bin";
+        };
+      };
+
+      "home-manager-expire" = {
+        Unit = {
+          Description = "home-manager expire-generations";
+          Documentation = "https://rycee.gitlab.io/home-manager/options.html";
+          After = [ "home-manager-switch.service" ];
+        };
+
+        Service.ExecStart = "%h/.nix-profile/bin/home-manager expire-generations \"-7 days\"";
+      };
+    };
+
+    timers = {
+      "home-manager-switch" = {
+        Timer.OnCalendar = "daily";
+        Install.WantedBy = [ "timers.target" ];
+      };
+
+      "home-manager-expire" = {
+        Timer.OnCalendar = "daily";
+        Install.WantedBy = [ "timers.target" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Move home-manager configuration to a separate module and bolsster the
systemd configuration so that we can drop fcron support completely for
automated updates to home-manager.