### PR TITLE
Remove Erlang language support.

### DIFF
--- a/languages/default.nix
+++ b/languages/default.nix
@@ -2,7 +2,6 @@
 {
   imports = [
     ./dhall.nix
-    ./erlang.nix
     ./haskell
     ./python.nix
     ./rust.nix

--- a/languages/erlang.nix
+++ b/languages/erlang.nix
@@ -1,7 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = [
-    pkgs.erlang
-    pkgs.rebar3
-  ];
-}


### PR DESCRIPTION
In an effort to use direnv more and nix-shell even more.  This is no
longer needed in my global environment.  If it is needed again we'll add
it.