### PR TITLE
Remove global dev tools.

### DIFF
--- a/languages/default.nix
+++ b/languages/default.nix
@@ -9,12 +9,7 @@
   ];
 
   home.packages = [
-    pkgs.cfssl
-    pkgs.gcc
-    pkgs.gitAndTools.pre-commit
-    pkgs.gnumake
     pkgs.pijul
-    pkgs.skaffold
     pkgs.tig
     pkgs.travis
   ];


### PR DESCRIPTION
I'm beginning to move these into direnv configurations with nix shell
bringing tools in via mkshell.  This means my central configuration can
be lighter and my development environments get more portable.